### PR TITLE
Add popup blocker notice if fail manager window fails to open

### DIFF
--- a/web-portal/novnc_oio/ui.js
+++ b/web-portal/novnc_oio/ui.js
@@ -394,6 +394,9 @@ const UI = {
         window.addEventListener('beforeunload', UI.closeFileBrowser);
         document.getElementById("OIO_warning_button")
             .addEventListener('click', UI.warningButtonOnClick);
+        document.getElementById("OIO_popup_button")
+            .addEventListener('click', () => {document.getElementById("OIO_popup_dlg").close();});
+        document.getElementById("OIO_popup_dialog_site").innerHTML = ` (${window.location.hostname}) `;
     },
 
 /* ------^-------
@@ -1319,6 +1322,13 @@ const UI = {
         url = nco ? `${url}/files/il/notefiles` : `${url}/files/il`;
         if (u && p) url = `${url}?u=${u}&p=${p}`;
         window.fileBrowserWindow = window.open(url, "_blank");
+        setTimeout(() => {
+            const w = window.fileBrowserWindow;
+            if(!w || w.closed || w.closed == "undefined"){
+                w && !w.closed && w.close();
+                document.getElementById('OIO_popup_dlg').showModal();
+            }
+        }, 1750);
     },
     
     closeFileBrowser() {

--- a/web-portal/novnc_oio/vnc.html
+++ b/web-portal/novnc_oio/vnc.html
@@ -344,6 +344,16 @@
             <label for="OIO_warning_checkbox">Do not show this notice again</label>
         </div>
     </dialog>
+
+    <dialog id="OIO_popup_dlg" class="OIO_dialog">
+        <h2>Error</h2>
+        <p>The File Manager tab failed to open.</p>
+        <p>This is likely due to a popup blocker on your browser.</p>
+        <p>Please disable popup blockers for this website<span id="OIO_popup_dialog_site"></span> in your browser settings and then try again.</p>
+        <div class="OIO_single-button-div">
+            <input type="button" id="OIO_popup_button" value="OK" class="OIO_main-button">
+        </div>
+    </dialog>
     <!-- END Interlisp Online -->
 
     <audio id="noVNC_bell">


### PR DESCRIPTION
Fixes Issue#718 (in interlisp/medley) "Online filesystem tab disappears"