### PR TITLE
Handle startup failures on reboot due to lingering docker containers

### DIFF
--- a/system/oio-dev.service
+++ b/system/oio-dev.service
@@ -12,6 +12,7 @@ Environment=NODE_ENV=development
 WorkingDirectory=/home/ubuntu
 ExecStart=/usr/bin/docker run \
                --name oio-dev \
+               --rm \
                -p 8080:80 \
                -p 8081:443 \
                -v /var/run/docker.sock:/var/run/docker.sock \
@@ -23,7 +24,6 @@ ExecStart=/usr/bin/docker run \
                :::DOCKER_REGISTRY:::===DOCKER_NAMESPACE===/online-development:latest
 Restart=no
 ExecStop=/usr/bin/docker container kill oio-dev
-ExecStop=/usr/bin/docker container rm oio-dev
 
 [Install]
 WantedBy=multi-user.target

--- a/system/oio.service
+++ b/system/oio.service
@@ -12,6 +12,7 @@ Environment=NODE_ENV=production
 WorkingDirectory=/home/ubuntu
 ExecStart=/usr/bin/docker run \
                --name oio \
+               --rm \
                -p 80:80 \
                -p 443:443 \
                -v /var/run/docker.sock:/var/run/docker.sock \
@@ -23,7 +24,6 @@ ExecStart=/usr/bin/docker run \
                :::DOCKER_REGISTRY:::===DOCKER_NAMESPACE===/online-production:latest
 Restart=always
 ExecStop=/usr/bin/docker container kill oio
-ExecStop=/usr/bin/docker container rm oio
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add --rm to docker run command for both oio.service and oio-dev.service to enable systemctl reboot to work correctly;  removed ExecStop=docker container rm clauses correspondingly