### PR TITLE
Response to Issue#190 in interlisp/medley repo:  Adding infrastructure that allows us to set the -m arg to online version of run-medley 

### DIFF
--- a/docker_medley/scripts/run-online-medley
+++ b/docker_medley/scripts/run-online-medley
@@ -6,7 +6,7 @@
 #
 #    2021-11-11 Frank Halasz
 #
-#    Copyright: 2022 by Interlisp.org 
+#    Copyright: 2022 by Interlisp.org
 #
 #
 #set -x
@@ -24,6 +24,13 @@ if [ "${NCO}" == "true" ];
    else VMEM_PATH="${MEDLEY_USERDIR}/vmem/lisp.virtualmem"
 fi
 
+if [ -z "${MEDLEY_MEMORY}" ];
+then
+    medley_memory_arg=""
+else
+    medley_memory_arg="-m ${MEDLEY_MEMORY}"
+fi
+
 if [ $# -gt 0 ]; then
     case "$1" in
 	    sysout)
@@ -32,14 +39,14 @@ if [ $# -gt 0 ]; then
 	    custom)
 			if [ -f ${CUSTOM_SYSOUT_PATH} ]; then
 				sysout=${CUSTOM_SYSOUT_PATH}
-			else 
+			else
 				sysout=${RELEASE_SYSOUT_PATH}
 			fi
 			;;
 	    vmem)
 			if [ -f ${VMEM_PATH} ]; then
 				sysout=""
-			else 
+			else
 				sysout=${RELEASE_SYSOUT_PATH}
 			fi
 			;;
@@ -73,14 +80,14 @@ else
 fi
 #
 export SFTP_PORT=2${PORT}
-if [ -z "${SFTP_SERVER}" ]; then 
+if [ -z "${SFTP_SERVER}" ]; then
     export SFTP_SERVER="false";
 fi
-if [ "${SFTP_SERVER}" == "true" ]; then 
+if [ "${SFTP_SERVER}" == "true" ]; then
     /usr/sbin/sshd -e -p ${SFTP_PORT}
 fi
 #
-if [ -z "${SFTP_PWD}" ]; then 
+if [ -z "${SFTP_PWD}" ]; then
     export SFTP_PWD=$(date +%s | sha256sum | base64 | head -c 8);
 fi
 echo medley:${SFTP_PWD} | chpasswd
@@ -95,7 +102,7 @@ export DISPLAY=:0
 for i in {1..10}
     do
         xdpyinfo > /dev/null
-        if [ $? -eq 0 ]; 
+        if [ $? -eq 0 ];
             then
                 break
             else
@@ -122,7 +129,7 @@ fi
 export FILEBROWSER_DATABASE=/usr/local/filebrowser/filebrowser.db
 export FILEBROWSER_PORT=3${PORT}
 if [ ${SUPPORT_HTTPS} = "yes" ];
-then 
+then
   export FILEBROWSER_CERT="--cert /etc/letsencrypt/live/online.interlisp.org/fullchain.pem"
   export FILEBROWSER_KEY="--key /etc/letsencrypt/live/online.interlisp.org/privkey.pem"
 else
@@ -153,5 +160,5 @@ export MEDLEYDIR=${MEDLEY_INSTALLDIR}
 export LOGINDIR=${MEDLEY_USERDIR}
 export LDEINIT=${MEDLEY_INIT_PATH}
 export MAIKODIR="/usr/local/interlisp/maiko"
-./run-medley -noscroll -g ${width}x${height} -sc ${width}x${height} -vmem ${VMEM_PATH} ${sysout}
+./run-medley -noscroll ${medley_memory_arg} -g ${width}x${height} -sc ${width}x${height} -vmem ${VMEM_PATH} ${sysout}
 EOF

--- a/web-portal/server/js/config.js
+++ b/web-portal/server/js/config.js
@@ -1,15 +1,15 @@
 /*******************************************************************************
- * 
- *   config.js: Global configuration settings for online.interlisp.org web portal
- * 
- * 
- *   2021-11-16 Frank Halasz
- * 
- * 
- *   Copyright: 2021-2022 by Interlisp.org 
- * 
  *
- ******************************************************************************///
+ *   config.js: Global configuration settings for online.interlisp.org web portal
+ *
+ *
+ *   2021-11-16 Frank Halasz
+ *
+ *
+ *   Copyright: 2021-2022 by Interlisp.org
+ *
+ *
+ *******************************************************************************/
 
 var path = require('path');
 var fs = require('fs');
@@ -131,12 +131,12 @@ var isGuestUser = function isGuestUser(username) { return (guestUsername == user
 exports.isGuestUser = isGuestUser;
 
 const badchars = new RegExp("[!#$%&'*+/=?^`{|}~]", "g");
-var emailish = 
-    function(email) { 
+var emailish =
+    function(email) {
         if(isGuestUser(email))
             return `guest-${Math.floor(Math.random() * 99999)}`;
         else
-            return email.replace(badchars, '-').replace("@", ".-."); 
+            return email.replace(badchars, '-').replace("@", ".-.");
     };
 exports.emailish = emailish;
 
@@ -147,3 +147,6 @@ var isNCO = function(req) {
     return (req.hostname.toLowerCase().replace(/^www\./,"") == "notecards.online");
 };
 exports.isNCO = isNCO;
+
+var medleyMemoryArg = "64";
+exports.medleyMemoryArg = medleyMemoryArg;

--- a/web-portal/server/js/medley.js
+++ b/web-portal/server/js/medley.js
@@ -1,15 +1,15 @@
 /*******************************************************************************
- * 
+ *
  *   medley.js:  Router to handle starting up Interlisp (and xterm) on the
  *               online.interlis.org web portal.  Mainly used to call
  *               docker to startup medley docker containers as needed.
- * 
- * 
+ *
+ *
  *   2021-11-22 Frank Halasz
- * 
- * 
- *   Copyright: 2021-2022 by Interlisp.org 
- * 
+ *
+ *
+ *   Copyright: 2021-2022 by Interlisp.org
+ *
  *
  ******************************************************************************/
 
@@ -74,6 +74,7 @@ function medleyEnvs(req) {
             + ` --env MEDLEY_INITIALS='${u.initials || "medley"}'`
             + ` --env RUN_NOTECARDS=${nc}`
             + ` --env MEDLEY_EXEC=${exec}`
+            + ` --env MEDLEY_MEMORY=${config.medleyMemoryArg}`
     ;
 }
 
@@ -170,7 +171,7 @@ function killIfNeeded(req, res, next) {
         docker
             .command(`container kill ${req.emailish}`)
             .then(data => { req.isRunning = false; next(); })
-            .catch(err => { console.log(err); res.status(500).send(err); } );        
+            .catch(err => { console.log(err); res.status(500).send(err); } );
     }
     else {
         next();
@@ -233,7 +234,7 @@ function returnCheckSession(req, res, next) {
 
 function filterGuest(req, res,next) {
     if(config.isGuestUser(req.user.username)) {
-        res.status(403); 
+        res.status(403);
         res.send("xterm not allowed for guest");
     }
     else next();


### PR DESCRIPTION
Currently set in config.js to "64" and passed via the "MEDLEY_MEMORY" environment variable to the run-online-medley script within the online-medley docker container.  run-online-medley uses it to set the -m arg in the call to run-medley.

Later on can get rid of the hardwired value in config.js and pass the value down from the oio client.