### PR TITLE
Fgh035:  Fix install of gh with dockerfile_medley && switch filebrowser exe to use git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 docker_medley/filebrowser/filebrowser filter=lfs diff=lfs merge=lfs -text
+docker_medley/gh/*.deb filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/buildMedleyDocker.yml
+++ b/.github/workflows/buildMedleyDocker.yml
@@ -73,6 +73,10 @@ jobs:
       # Checkout latest commit
       - name: Checkout Online code
         uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Checkout lfs files
+        run: git lfs checkout
 
       # Setup release tag
       - name: Setup Release Tag
@@ -169,6 +173,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Set up platform variable so it can be used by Docker build
+      - name: Strip the linux/ from the platform input 
+        id: platform_var
+        run: |
+          echo ::set-output name=platform::$(echo "${{ needs.inputs.outputs.platform }}" | sed s-linux/--)
+
       # Do the Docker Build using the Dockerfile in the repository
       # checked out and the release tars just downloaded.
       # Push the result to Docker Hub
@@ -184,6 +194,7 @@ jobs:
             DOCKER_NAMESPACE=${{ steps.release_info.outputs.docker_namespace }}
             REPO_OWNER=${{ github.repository_owner }}
             NOTECARDS_RELEASE=${{ steps.nc_release_info.outputs.nc_release_tag }}
+            PLATFORM=${{ steps.platform_var.outputs.platform }}
           context: ./docker_medley
           file: ./docker_medley/Dockerfile_medley
           platforms: ${{ needs.inputs.outputs.platform }}

--- a/docker_medley/Dockerfile_medley
+++ b/docker_medley/Dockerfile_medley
@@ -61,7 +61,8 @@ RUN apt-get update \
     && apt-get install -y git
 
 # install gh (github cli)
-RUN dpkg -i gh/gh_2.14.7_linux_${PLATFORM}.deb
+COPY gh/gh_2.14.7_linux_*.deb /tmp
+RUN dpkg -i /tmp/gh_2.14.7_linux_${PLATFORM}.deb; rm /tmp/gh_2.14.7_linux_*.deb
 
 #  install websockify for use with noVNC
 RUN apt-get install -y websockify

--- a/docker_medley/Dockerfile_medley
+++ b/docker_medley/Dockerfile_medley
@@ -29,6 +29,7 @@ ARG MAIKO_RELEASE=unknown
 ARG MEDLEY_RELEASE=unknown
 ARG NOTECARDS_RELEASE=unknown
 ARG REPO_OWNER=Interlisp
+ARG PLATFORM=amd64
 
 LABEL name="online.interlisp.org"
 LABEL description="The Medley Interlisp environment used by online.interlisp.org"
@@ -53,14 +54,14 @@ ENV MEDLEY_USERDIR=${HOMEDIR}/il
 ARG NC_INSTALLDIR=/usr/local/interlisp/notecards
 ENV NC_INSTALLDIR=${NC_INSTALLDIR}
 
-# install git & gh (github cli) 
+# install apt-utils, curl, git 
 RUN apt-get update \
     && apt-get install -y apt-utils \
     && apt-get install -y curl \
-    && ( curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg ) \
-    && ( echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null ) \
-    && apt-get update \
-    && apt-get install -y git gh
+    && apt-get install -y git
+
+# install gh (github cli)
+RUN dpkg -i gh/gh_2.14.7_linux_${PLATFORM}.deb
 
 #  install websockify for use with noVNC
 RUN apt-get install -y websockify

--- a/docker_medley/gh/gh_2.14.7_linux_amd64.deb
+++ b/docker_medley/gh/gh_2.14.7_linux_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7ee6f6eb9fb75621bad26b8de7cf457700c33d2f93065a73a77bb3a7a135036
+size 8087444

--- a/docker_medley/gh/gh_2.14.7_linux_arm64.deb
+++ b/docker_medley/gh/gh_2.14.7_linux_arm64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3133da481e0cdb65e96fbd9c1f03387a1ef47e0c3d7ffd4b3ecb9baa0b4b7294
+size 7373838


### PR DESCRIPTION
1) Install of gh in building the online Medley docker image was broken by changes at github.  As recommended by github, moved to installing gh via a *.deb file.  Once we move to ubuntu 22.04, we can install gh from the ubuntu repo.  But this is not available for 20.04.

2) Moved filebrowser exe (as well as new gh *.deb files) to use git lfs.
