### PR TITLE
Handle warning dialogs for filebrowser & clhs for guest logins a bit better

### DIFF
--- a/web-portal/client/novnc_oio/ui.js
+++ b/web-portal/client/novnc_oio/ui.js
@@ -1291,17 +1291,21 @@ const UI = {
             window.fileBrowserWindow.focus();
 
         } else {
-            let noWarn;
+            let noWarn = false;
+            let guest = false;
             let response = await window.fetch('/user/nofilemgrwarning');
             if(response.ok) {
                 let txt = await response.text();
                 noWarn = (txt == "true");
+                guest = (txt == "guest");
             }
-            else noWarn = false;
             if(noWarn)
               UI.openFileBrowserFinish();
-            else
-              document.getElementById('OIO_warning_dlg').showModal();
+            else {
+              const dlg = document.getElementById('OIO_warning_dlg');
+	      if(guest) document.getElementById('OIO_do_not_checkbox_div').hidden = true;
+              dlg.showModal();
+            }
         }
     },
 
@@ -1352,17 +1356,19 @@ const UI = {
     //
 
     async openCLHSTab(url) {
-        let noWarn;
+        let noWarn = false;
+        let guest = false;
         let response = await window.fetch('/user/clhstabnotice');
         if(response.ok) {
             let txt = await response.text();
             noWarn = (txt == "true");
+            guest = (txt == "guest");
         }
-        else noWarn = false;
         if(noWarn)
           UI.openCLHSTabFinish(url);
         else {
             const dlg = document.getElementById('OIO_CLHS_tab_notice_dlg');
+	    if(guest) document.getElementById('OIO_CLHS_do_not_checkbox_div').hidden = true;
             dlg.clhsURL = url;
             dlg.showModal();
         }

--- a/web-portal/server/js/user.js
+++ b/web-portal/server/js/user.js
@@ -366,13 +366,17 @@ userRouter.get('/nofilemgrwarning',
                 res.status(500).send('Error');
             }
         } else {
-            try {
-                const userObj = await userModel.findOne({ username: req.user.username });
-                const noWarning = userObj.noFileMgrWarning;
-                res.status(200).send(noWarning ? "true" : "false");
-            } catch(err) {
-                console.dir("/nofilemgrwarning error: " + err);
-                res.status(500).send('Error');
+            if(config.isGuestUser(req.user.username))
+                res.status(200).send("guest");
+            else {
+                try {
+                    const userObj = await userModel.findOne({ username: req.user.username });
+                    const noWarning = userObj.noFileMgrWarning;
+                    res.status(200).send(noWarning ? "true" : "false");
+                } catch(err) {
+                    console.dir("/nofilemgrwarning error: " + err);
+                    res.status(500).send('Error');
+                }
             }
         }
     }
@@ -395,13 +399,17 @@ userRouter.get('/clhstabnotice',
                 res.status(500).send('Error');
             }
         } else {
-            try {
-                const userObj = await userModel.findOne({ username: req.user.username });
-                const noNotice = userObj.noCLHSTabNotice;
-                res.status(200).send(noNotice ? "true" : "false");
-            } catch(err) {
-                console.dir("/clhstabnotice error: " + err);
-                res.status(500).send('Error');
+            if(config.isGuestUser(req.user.username))
+                res.status(200).send("guest");
+            else {
+                try {
+                    const userObj = await userModel.findOne({ username: req.user.username });
+                    const noNotice = userObj.noCLHSTabNotice;
+                    res.status(200).send(noNotice ? "true" : "false");
+                } catch(err) {
+                    console.dir("/clhstabnotice error: " + err);
+                    res.status(500).send('Error');
+                }
             }
         }
     }


### PR DESCRIPTION
Specifically, get rid of "Do not show again" checkboxes, so that simultaneous guest users don't overrun each other on this matter.  The warning dialogs for fileb manager and for the CLHS tab opening are just always shown to guests - everytime.  Don't like it - register.