### PR TITLE
Fix bugs with cross-talk between multiple simultaneous users of OIO

### DIFF
--- a/docker_medley/scripts/run-online-medley
+++ b/docker_medley/scripts/run-online-medley
@@ -99,8 +99,8 @@ if [ ${SUPPORT_HTTPS} = "yes" ];
 fi
 /usr/bin/Xvnc -geometry ${width}x${height} -rfbport 1${PORT} -SecurityTypes None \
               -nolisten tcp -localhost -NeverShared -DisconnectClients=0 \
-              :0 &
-export DISPLAY=:0
+              :${PORT} &
+export DISPLAY=:${PORT}
 for i in {1..10}
     do
         xdpyinfo > /dev/null

--- a/docker_medley/scripts/run-xterm
+++ b/docker_medley/scripts/run-xterm
@@ -39,8 +39,10 @@ if [ ${SUPPORT_HTTPS} = "yes" ];
   then /usr/bin/websockify --daemon --key ${TLS_KEYFILE} --cert ${TLS_CERTFILE} --ssl-only ${PORT} localhost:1${PORT}
   else /usr/bin/websockify --daemon  ${PORT} localhost:1${PORT}
 fi
-/usr/bin/Xvnc -geometry ${width}x${height} -rfbport 1${PORT} -nolisten tcp -localhost -nevershared -dontdisconnect :0 &
-export DISPLAY=:0
+/usr/bin/Xvnc -geometry ${width}x${height} -rfbport 1${PORT} -nolisten tcp -localhost \
+              -nevershared -dontdisconnect\
+              :${PORT} &
+export DISPLAY=:${PORT}
 for i in {1..10}
     do
         xdpyinfo > /dev/null

--- a/docker_medley/scripts/run-xterm
+++ b/docker_medley/scripts/run-xterm
@@ -39,8 +39,8 @@ if [ ${SUPPORT_HTTPS} = "yes" ];
   then /usr/bin/websockify --daemon --key ${TLS_KEYFILE} --cert ${TLS_CERTFILE} --ssl-only ${PORT} localhost:1${PORT}
   else /usr/bin/websockify --daemon  ${PORT} localhost:1${PORT}
 fi
-/usr/bin/Xvnc -geometry ${width}x${height} -rfbport 1${PORT} -nolisten tcp -localhost \
-              -nevershared -dontdisconnect\
+/usr/bin/Xvnc -geometry ${width}x${height} -rfbport 1${PORT} -SecurityTypes None \
+              -nolisten tcp -localhost -NeverShared -DisconnectClients=0 \
               :${PORT} &
 export DISPLAY=:${PORT}
 for i in {1..10}

--- a/web-portal/server/js/config.js
+++ b/web-portal/server/js/config.js
@@ -151,6 +151,6 @@ exports.isNCO = isNCO;
 var medleyMemoryArg = "64";
 exports.medleyMemoryArg = medleyMemoryArg;
 
-var networkHostMode = false;
-exports networkHostMode = networkHostMode;
+var medleyNetworkHostMode = false;
+exports.medleyNetworkHostMode = medleyNetworkHostMode;
 

--- a/web-portal/server/js/config.js
+++ b/web-portal/server/js/config.js
@@ -150,3 +150,7 @@ exports.isNCO = isNCO;
 
 var medleyMemoryArg = "64";
 exports.medleyMemoryArg = medleyMemoryArg;
+
+var networkHostMode = false;
+exports networkHostMode = networkHostMode;
+

--- a/web-portal/server/js/medley.js
+++ b/web-portal/server/js/medley.js
@@ -130,7 +130,7 @@ function xtermRunCmd(req) {
     const port = req.oioPort;
     const cmd =
         `run -d ${config.noDockerRm ? "" : "--rm"}`
-        + ` --network host`
+        + networkParams(port)
         + ` --name ${emailish}${config.isDev ? `-${Math.floor(Math.random() * 99999)}` : ``}`
         + ` --mount type=volume,source=${emailish}_home.v2,target=/home/medley`
         + dockerTlsMounts

--- a/web-portal/server/js/medley.js
+++ b/web-portal/server/js/medley.js
@@ -80,7 +80,7 @@ function medleyEnvs(req) {
 
 function networkParams(port) {
     var params;
-    if (config.networkHostMode === true)
+    if (config.medleyNetworkHostMode === true)
         params =` --network host`;
     else
         params =

--- a/web-portal/server/js/medley.js
+++ b/web-portal/server/js/medley.js
@@ -78,6 +78,21 @@ function medleyEnvs(req) {
     ;
 }
 
+function networkParams(port) {
+    var params;
+    if (config.networkHostMode === true)
+        params =` --network host`;
+    else
+        params =
+            ` --network bridge`
+            + ` -p ${port}:${port}`
+            + ` -p 1${port}:1${port}`
+            + ` -p 2${port}:2${port}`
+            + ` -p 3${port}:3${port}`
+            ;
+    return params;
+}
+
 function interlispRunCmd(req) {
     const emailish = req.emailish;
     const port = req.oioPort;
@@ -88,7 +103,7 @@ function interlispRunCmd(req) {
     const screen_height = req.query.screen_height || 808;
     const cmd =
             `run -d ${config.noDockerRm ? "" : "--rm"}`
-            + ` --network host`
+            + networkParams(port)
             + ` --name ${emailish}`
             + (config.isGuestUser(req.user.username) ? "" : ` --mount type=volume,source=${config.homeVolume(req.user.username)},target=/home/medley`)
             + dockerTlsMounts


### PR DESCRIPTION
Changed two things to isolate simultaneous users from each other:
1.  Made the X DISPLAY be ":<port number>" rather than always ":0", so each user has a guaranteed unique display number.
2.  Changed the networking mode for the Online Medley docker container from "host" to "bridge" and changed the docker run commands to bridge just the necessary ports from host to container.
3.   