### PR TITLE
Small changes to enable buildAndDeploy workflow to be called from Medley repo actions

### DIFF
--- a/.github/workflows/buildAndDeployMedleyDocker.yml
+++ b/.github/workflows/buildAndDeployMedleyDocker.yml
@@ -42,9 +42,13 @@ jobs:
     uses: ./.github/workflows/buildMedleyDocker.yml
     with:
       platform: ${{ inputs.platform }}
-    secrets: inherit
+    secrets:
+      CCRYPT_KEY: ${{ secrets.CCRYPT_KEY }}
+      OIO_SSH_KEY: ${{ secrets.OIO_SSH_KEY }}
   deploy:
     needs: build
     uses: ./.github/workflows/deployMedleyDocker.yml
-    secrets: inherit
+    secrets:
+      CCRYPT_KEY: ${{ secrets.CCRYPT_KEY }}
+      OIO_SSH_KEY: ${{ secrets.OIO_SSH_KEY }}
 

--- a/.github/workflows/buildAndDeployMedleyDocker.yml
+++ b/.github/workflows/buildAndDeployMedleyDocker.yml
@@ -44,11 +44,9 @@ jobs:
       platform: ${{ inputs.platform }}
     secrets:
       CCRYPT_KEY: ${{ secrets.CCRYPT_KEY }}
-      OIO_SSH_KEY: ${{ secrets.OIO_SSH_KEY }}
   deploy:
     needs: build
     uses: ./.github/workflows/deployMedleyDocker.yml
     secrets:
-      CCRYPT_KEY: ${{ secrets.CCRYPT_KEY }}
       OIO_SSH_KEY: ${{ secrets.OIO_SSH_KEY }}
 

--- a/.github/workflows/buildMedleyDocker.yml
+++ b/.github/workflows/buildMedleyDocker.yml
@@ -49,9 +49,9 @@ jobs:
     steps:
       - id: platform
         run: >
-          if [ '${{ toJSON(inputs) }}' = 'null'  ];
-          then echo "platform=${{ github.event.inputs.platform }}" >> ${GITHUB_OUTPUT};
-          else echo "platform=${{ inputs.platform }}" >> ${GITHUB_OUTPUT};
+          if [ '${{ toJSON(inputs) }}' = '{}'  ];
+          then echo "platform=${{ inputs.platform }}" >> ${GITHUB_OUTPUT};
+          else echo "platform=linux/amd64" >> ${GITHUB_OUTPUT};
           fi
 
 

--- a/.github/workflows/buildMedleyDocker.yml
+++ b/.github/workflows/buildMedleyDocker.yml
@@ -1,17 +1,16 @@
-# buildDocker.yml
+#  buildDocker.yml
 #
-# Workflow to build and push a multiplatform Docker image for the Medley that runs
-# on online.interlisp.org.
+#  Workflow to build and push a multiplatform Docker image for the Medley that runs
+#  on online.interlisp.org.
 #
-# This workflow uses the latest Medley docker image and the latest Interlisp/online
-# release on github.
+#  This workflow uses the latest Medley docker image and the latest Interlisp/online
+#  release on github.
 #
 #    2022-01-19 by Frank Halasz based on Medley buildDocker.yml
 #
 #
 #    Copyright: 2022 by Interlisp.org 
 #
-#set -x
 #
 
 name: 'Build/Push Online-Medley Docker Image'
@@ -70,11 +69,10 @@ jobs:
         if: steps.cache-lfs.outputs.cache-hit == 'true'
         run: mv docker_medley ../save_docker_medley
 
-      # Checkout latest (online) commit
+      # Checkout latest commit
       - name: Checkout Online code
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.repository_owner }}/online
           lfs: ${{ steps.cache-lfs.outputs.cache-hit != 'true' }}
 
       - name: Checkout lfs files

--- a/.github/workflows/buildMedleyDocker.yml
+++ b/.github/workflows/buildMedleyDocker.yml
@@ -70,10 +70,11 @@ jobs:
         if: steps.cache-lfs.outputs.cache-hit == 'true'
         run: mv docker_medley ../save_docker_medley
 
-      # Checkout latest commit
+      # Checkout latest (online) commit
       - name: Checkout Online code
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.repository_owner }}/online
           lfs: ${{ steps.cache-lfs.outputs.cache-hit != 'true' }}
 
       - name: Checkout lfs files

--- a/.github/workflows/buildMedleyDocker.yml
+++ b/.github/workflows/buildMedleyDocker.yml
@@ -39,22 +39,6 @@ on:
 
 jobs:
 
-  # Regularize the inputs so they can be referenced the same way whether they are
-  # the result of a workflow_dispatch or a workflow_call
-
-  inputs:
-    runs-on: ubuntu-latest
-    outputs:
-      platform: ${{ steps.platform.outputs.platform }}
-    steps:
-      - id: platform
-        run: >
-          if [ '${{ toJSON(inputs) }}' = '{}'  ];
-          then echo "platform=${{ inputs.platform }}" >> ${GITHUB_OUTPUT};
-          else echo "platform=linux/amd64" >> ${GITHUB_OUTPUT};
-          fi
-
-
   # Build and push the docker image
 
   build_and-push:
@@ -164,7 +148,7 @@ jobs:
 
       # Setup the Docker Machine Emulation environment.  
       - name: Set up QEMU
-        if: ${{ needs.inputs.outputs.platform == 'linux/arm64' }}
+        if: ${{ inputs.platform == 'linux/arm64' }}
         uses: docker/setup-qemu-action@master
         with:
           platforms: linux/arm64
@@ -186,7 +170,7 @@ jobs:
       - name: Strip the linux/ from the platform input
         id: platform_var
         run: |
-          echo "platform=$(echo "${{ needs.inputs.outputs.platform }}" | sed s-linux/--)"  >> ${GITHUB_OUTPUT}
+          echo "platform=$(echo "${{ inputs.platform }}" | sed s-linux/--)"  >> ${GITHUB_OUTPUT}
 
       # Do the Docker Build using the Dockerfile in the repository
       # checked out and the release tars just downloaded.
@@ -206,6 +190,6 @@ jobs:
             PLATFORM=${{ steps.platform_var.outputs.platform }}
           context: ./docker_medley
           file: ./docker_medley/Dockerfile_medley
-          platforms: ${{ needs.inputs.outputs.platform }}
+          platforms: ${{ inputs.platform }}
           push: true
           tags: ${{ steps.docker_env.outputs.docker_tags }}

--- a/.github/workflows/buildMedleyDocker.yml
+++ b/.github/workflows/buildMedleyDocker.yml
@@ -42,7 +42,7 @@ jobs:
   # Build and push the docker image
 
   build_and-push:
-    needs: inputs
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
These changes are minor cleanups that were intended to make possible calling the buildAndDeploy workflow from the Medley github actions.  Turns out they weren't really needed.  But they were cleanups, so leaving them in.