### PR TITLE
Update all Github actions to latest versions to account for Node 20 deprecation in Github runners and move to Node 24

### DIFF
--- a/.github/workflows/buildDarkstarDocker.yml
+++ b/.github/workflows/buildDarkstarDocker.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       # Checkout the actions for this repo_owner
       - name: Checkout Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository_owner }}/.github
           path: ./Actions_${{ github.sha }}
@@ -88,7 +88,7 @@ jobs:
 
       # Checkout latest commit
       - name: Checkout Online code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           lfs: ${{ steps.cache-lfs.outputs.cache-hit != 'true' }}
 
@@ -135,7 +135,7 @@ jobs:
 
       # Checkout the latest Notecards commit
       - name: Checkout Notecards
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: "${{ github.repository_owner }}/notecards"
           path: "./docker_medley/notecards"

--- a/.github/workflows/buildDarkstarDocker.yml
+++ b/.github/workflows/buildDarkstarDocker.yml
@@ -73,7 +73,7 @@ jobs:
       # Fetch cached LFS files
       - name: Cache LFS files
         id: cache-lfs
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
             path: |
                 docker_medley/filebrowser/filebrowser
@@ -194,7 +194,7 @@ jobs:
 
       # Login to ghcr.io
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2 
+        uses: docker/login-action@v4 
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -210,7 +210,7 @@ jobs:
       # checked out and the release tars just downloaded.
       # Push the result to Docker Hub
       - name: Build Docker Image for Push to Docker Hub
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |

--- a/.github/workflows/buildMedleyDocker.yml
+++ b/.github/workflows/buildMedleyDocker.yml
@@ -56,7 +56,7 @@ jobs:
       # Fetch cached LFS files
       - name: Cache LFS files
         id: cache-lfs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
             path: |
                 docker_medley/filebrowser/filebrowser
@@ -160,7 +160,7 @@ jobs:
 
       # Login to ghcr.io
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -176,7 +176,7 @@ jobs:
       # checked out and the release tars just downloaded.
       # Push the result to Docker Hub
       - name: Build Docker Image for Push to Docker Hub
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |

--- a/.github/workflows/buildMedleyDocker.yml
+++ b/.github/workflows/buildMedleyDocker.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       # Checkout the actions for this repo_owner
       - name: Checkout Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository_owner }}/.github
           path: ./Actions_${{ github.sha }}
@@ -71,7 +71,7 @@ jobs:
 
       # Checkout latest commit
       - name: Checkout Online code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           lfs: ${{ steps.cache-lfs.outputs.cache-hit != 'true' }}
 
@@ -116,7 +116,7 @@ jobs:
 
       # Checkout the latest Notecards commit
       - name: Checkout Notecards
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "${{ github.repository_owner }}/notecards"
           path: "./docker_medley/notecards"

--- a/.github/workflows/buildPortalDocker.yml
+++ b/.github/workflows/buildPortalDocker.yml
@@ -73,7 +73,7 @@ jobs:
 
       # Checkout the actions for this repo_owner
       - name: Checkout Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository_owner }}/.github
           path: ./Actions_${{ github.sha }}
@@ -81,7 +81,7 @@ jobs:
 
       # Checkout latest commit to depth 1 for production
       - name: Checkout Web-portal code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -143,7 +143,7 @@ jobs:
 
       # Get novnc
       - name: Checkout novnc code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'novnc/noVNC.git'
           ref: 'v1.3.0'
@@ -166,7 +166,7 @@ jobs:
 
       # Recheckout latest commit with fetch_depth of 0 for development image
       - name: Checkout Web-portal code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -177,7 +177,7 @@ jobs:
 
       # Get novnc
       - name: Checkout novnc code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'novnc/noVNC.git'
           ref: 'v1.3.0'

--- a/.github/workflows/buildPortalDocker.yml
+++ b/.github/workflows/buildPortalDocker.yml
@@ -130,7 +130,7 @@ jobs:
 
       # Login to ghcr.io
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -152,7 +152,7 @@ jobs:
       # Do the Production Docker Build using the Dockerfile_production
       # Push the result to Docker Hub
       - name: Build Docker Image for Push to Docker Hub
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |
@@ -186,7 +186,7 @@ jobs:
       # Do the Development Docker Build using the Dockerfile_development
       # Push the result to Docker Hub
       - name: Build Docker Image for Push to Docker Hub
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |


### PR DESCRIPTION
Update all Github actions to latest versions to account for Node 20 deprecation in Github runners and move to Node 24